### PR TITLE
Next content integration

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -1,0 +1,403 @@
+# Mace Neutralizer Configuration Guide
+
+This guide provides detailed information about configuring the Mace Neutralizer mod.
+
+## Table of Contents
+
+- [Configuration File](#configuration-file)
+- [Entity Categories](#entity-categories)
+- [Custom Entity Lists](#custom-entity-lists)
+- [Command Reference](#command-reference)
+- [Use Case Examples](#use-case-examples)
+- [Troubleshooting](#troubleshooting)
+
+## Configuration File
+
+The configuration file is located at `config/mace-neutralizer.json` in your server directory.
+
+### File Structure
+
+```json
+{
+  "enabled": true,
+  "damageAmount": 1.0,
+  "affectPassiveMobs": true,
+  "affectHostileMobs": true,
+  "affectBosses": true,
+  "affectPlayers": false,
+  "customAffectedEntities": [],
+  "customExcludedEntities": []
+}
+```
+
+### Configuration Fields
+
+#### `enabled` (boolean)
+Master toggle for the entire mod.
+- `true`: Mod is active
+- `false`: Mod is disabled (mace deals normal damage)
+
+#### `damageAmount` (float)
+The amount of damage the mace will deal when the mod is active.
+- Value is in half-hearts (2.0 = 1 heart)
+- Minimum: 0.0 (no damage, but wind burst still works)
+- Examples:
+  - `0.0` = No damage
+  - `1.0` = 0.5 hearts (default)
+  - `2.0` = 1 heart
+  - `4.0` = 2 hearts
+  - `20.0` = 10 hearts
+
+#### `affectPassiveMobs` (boolean)
+Whether to apply the damage modification to passive/neutral mobs.
+- Includes: Cows, Pigs, Sheep, Chickens, Horses, Villagers, Iron Golems, etc.
+- Default: `true`
+
+#### `affectHostileMobs` (boolean)
+Whether to apply the damage modification to hostile mobs.
+- Includes: Zombies, Skeletons, Creepers, Spiders, Endermen, etc.
+- Default: `true`
+
+#### `affectBosses` (boolean)
+Whether to apply the damage modification to boss mobs.
+- Includes: Ender Dragon, Wither, Warden, Elder Guardian
+- Default: `true`
+
+#### `affectPlayers` (boolean)
+Whether to apply the damage modification when attacking players.
+- Default: `false` (players take normal mace damage)
+
+#### `customAffectedEntities` (array of strings)
+List of entity class names that should always be affected, regardless of category settings.
+- Overrides category settings
+- Use full Java class names
+- Example: `["net.minecraft.entity.passive.VillagerEntity"]`
+
+#### `customExcludedEntities` (array of strings)
+List of entity class names that should never be affected (highest priority).
+- Overrides both category settings and customAffectedEntities
+- Use full Java class names
+- Example: `["net.minecraft.entity.passive.HorseEntity"]`
+
+## Entity Categories
+
+### Passive Mobs
+Entities that extend `PassiveEntity`:
+- Cow, Sheep, Pig, Chicken
+- Horse, Donkey, Mule, Llama
+- Rabbit, Fox, Wolf (when not angry)
+- Cat, Parrot, Panda
+- Villager, Iron Golem
+- Axolotl, Frog, Turtle
+- And more...
+
+### Hostile Mobs
+Entities that extend `HostileEntity` or implement `Monster`:
+- Zombie, Skeleton, Creeper
+- Spider, Cave Spider
+- Enderman, Silverfish
+- Witch, Phantom
+- Drowned, Husk, Stray
+- Vindicator, Pillager, Evoker
+- And more...
+
+### Bosses
+Special boss entities:
+- Ender Dragon
+- Wither
+- Warden
+- Elder Guardian
+
+### Players
+All player entities (online players).
+
+## Custom Entity Lists
+
+Custom entity lists provide fine-grained control over specific entity types.
+
+### Priority Order
+
+The mod checks entities in this priority order:
+1. **Custom Excluded Entities** (highest priority)
+2. **Custom Affected Entities**
+3. **Category Settings** (passive/hostile/bosses/players)
+4. **Default** (not affected)
+
+### Finding Entity Class Names
+
+To find an entity's class name:
+
+1. **In-game debug screen**: Press F3 and look at the entity
+2. **Minecraft Wiki**: Most pages list the entity ID
+3. **Common pattern**: `net.minecraft.entity.<type>.<Name>Entity`
+
+### Example: Complex Configuration
+
+Protect villagers and horses, but affect everything else:
+
+```json
+{
+  "enabled": true,
+  "damageAmount": 1.0,
+  "affectPassiveMobs": true,
+  "affectHostileMobs": true,
+  "affectBosses": true,
+  "affectPlayers": false,
+  "customAffectedEntities": [],
+  "customExcludedEntities": [
+    "net.minecraft.entity.passive.VillagerEntity",
+    "net.minecraft.entity.passive.HorseEntity"
+  ]
+}
+```
+
+Or via commands:
+```
+/maceneutralizer custom exclude net.minecraft.entity.passive.VillagerEntity
+/maceneutralizer custom exclude net.minecraft.entity.passive.HorseEntity
+```
+
+## Command Reference
+
+### Quick Command Guide
+
+| Command | Description | Example |
+|---------|-------------|---------|
+| `/maceneutralizer` | Show status | - |
+| `/maceneutralizer toggle` | Toggle on/off | - |
+| `/maceneutralizer set <bool>` | Enable/disable | `/maceneutralizer set false` |
+| `/maceneutralizer damage <amount>` | Set damage | `/maceneutralizer damage 2.0` |
+| `/maceneutralizer entities <type> <bool>` | Toggle category | `/maceneutralizer entities passive false` |
+| `/maceneutralizer custom add <class>` | Add to affected | `/maceneutralizer custom add net.minecraft.entity.passive.CowEntity` |
+| `/maceneutralizer custom exclude <class>` | Add to excluded | `/maceneutralizer custom exclude net.minecraft.entity.passive.VillagerEntity` |
+| `/maceneutralizer reload` | Reload config | - |
+
+### Tab Completion
+
+The mod provides tab completion for:
+- Command structure (all subcommands)
+- Boolean values (true/false)
+- Common entity class names
+- Currently configured custom entities (for removal)
+
+## Use Case Examples
+
+### Use Case 1: Peaceful Server with Mace Challenges
+
+**Goal**: Keep mace damage normal for bosses, but minimal for everything else.
+
+**Configuration**:
+```json
+{
+  "enabled": true,
+  "damageAmount": 1.0,
+  "affectPassiveMobs": true,
+  "affectHostileMobs": true,
+  "affectBosses": false,
+  "affectPlayers": false
+}
+```
+
+**Commands**:
+```
+/maceneutralizer entities passive true
+/maceneutralizer entities hostile true
+/maceneutralizer entities bosses false
+/maceneutralizer damage 1.0
+```
+
+### Use Case 2: PvP Server with Wind Burst Only
+
+**Goal**: Mace deals no damage but wind burst enchantment works for knockback.
+
+**Configuration**:
+```json
+{
+  "enabled": true,
+  "damageAmount": 0.0,
+  "affectPassiveMobs": true,
+  "affectHostileMobs": true,
+  "affectBosses": true,
+  "affectPlayers": true
+}
+```
+
+**Commands**:
+```
+/maceneutralizer damage 0.0
+/maceneutralizer entities players true
+```
+
+### Use Case 3: Villager Trading Protection
+
+**Goal**: Protect villagers from accidental mace deaths, keep everything else normal.
+
+**Configuration**:
+```json
+{
+  "enabled": true,
+  "damageAmount": 1.0,
+  "affectPassiveMobs": false,
+  "affectHostileMobs": false,
+  "affectBosses": false,
+  "affectPlayers": false,
+  "customAffectedEntities": [
+    "net.minecraft.entity.passive.VillagerEntity"
+  ]
+}
+```
+
+**Commands**:
+```
+/maceneutralizer entities passive false
+/maceneutralizer custom add net.minecraft.entity.passive.VillagerEntity
+/maceneutralizer damage 0.0
+```
+
+### Use Case 4: Mob Grinder Friendly
+
+**Goal**: Disable mace for hostile mobs only, to prevent one-shotting in grinders.
+
+**Configuration**:
+```json
+{
+  "enabled": true,
+  "damageAmount": 1.0,
+  "affectPassiveMobs": false,
+  "affectHostileMobs": true,
+  "affectBosses": false,
+  "affectPlayers": false
+}
+```
+
+**Commands**:
+```
+/maceneutralizer entities hostile true
+/maceneutralizer entities passive false
+/maceneutralizer entities bosses false
+```
+
+### Use Case 5: Custom Modded Entity Control
+
+**Goal**: Affect a specific modded entity that doesn't fit standard categories.
+
+**Commands**:
+```
+/maceneutralizer custom add com.example.mod.CustomBossEntity
+```
+
+The entity will now always be affected, regardless of category settings.
+
+## Troubleshooting
+
+### Config Not Loading
+
+**Problem**: Changes to config file aren't taking effect.
+
+**Solutions**:
+1. Check JSON syntax is valid (use a JSON validator)
+2. Ensure file is saved with UTF-8 encoding
+3. Run `/maceneutralizer reload` to reload from disk
+4. Restart the server
+
+### Entity Not Being Affected
+
+**Problem**: A specific entity isn't being affected by the mod.
+
+**Diagnosis**:
+1. Check if the mod is enabled: `/maceneutralizer status`
+2. Check the entity's category is enabled
+3. Check if entity is in custom excluded list
+4. Verify the entity is actually a `LivingEntity`
+
+**Solution**:
+```
+/maceneutralizer status
+/maceneutralizer entities list
+/maceneutralizer custom list
+```
+
+If needed, explicitly add the entity:
+```
+/maceneutralizer custom add <entity_class_name>
+```
+
+### Finding Entity Class Names
+
+**Problem**: Don't know the class name for a modded entity.
+
+**Solutions**:
+1. Check the mod's source code or documentation
+2. Use a tool like NBT Explorer to examine entity data
+3. Enable debug mode in Minecraft (F3) and look at entity data
+4. Check the mod's GitHub repository or wiki
+
+### Config File Corrupted
+
+**Problem**: Config file is corrupted or has invalid JSON.
+
+**Solution**:
+1. Delete the config file: `config/mace-neutralizer.json`
+2. Restart the server (a new default config will be created)
+3. Reconfigure using commands or edit the new file
+
+### Commands Not Working
+
+**Problem**: Commands return "Unknown command" or permission errors.
+
+**Diagnosis**:
+- Commands require OP level 2 (Gamemaster permission)
+- Mod must be installed correctly
+
+**Solution**:
+1. Verify you have permission: `/op <username>`
+2. Check mod is loaded: `/fabric mods` (if you have Fabric API debug commands)
+3. Check server logs for errors
+
+## Advanced Tips
+
+### Backup Your Config
+
+Before making major changes:
+```bash
+cp config/mace-neutralizer.json config/mace-neutralizer.json.backup
+```
+
+### Batch Configuration
+
+Edit the JSON file directly for complex setups:
+```json
+{
+  "customExcludedEntities": [
+    "net.minecraft.entity.passive.VillagerEntity",
+    "net.minecraft.entity.passive.HorseEntity",
+    "net.minecraft.entity.passive.CatEntity",
+    "net.minecraft.entity.passive.WolfEntity"
+  ]
+}
+```
+
+Then reload: `/maceneutralizer reload`
+
+### Performance
+
+The mod is highly optimized:
+- Thread-safe concurrent access
+- No performance impact when disabled
+- Minimal overhead per attack (single config check)
+
+### Testing Changes
+
+Create a test world or use a test server to verify configuration before applying to production.
+
+## Support
+
+If you encounter issues not covered here:
+
+1. Check the [GitHub Issues](https://github.com/sahibkhokhar/mace-neutralizer/issues)
+2. Review server logs for error messages
+3. Open a new issue with:
+   - Your configuration file
+   - Server logs
+   - Steps to reproduce
+   - Expected vs actual behavior

--- a/README.md
+++ b/README.md
@@ -1,20 +1,268 @@
 # Mace Neutralizer
 
-A Fabric mod that makes maces deal minimal fixed damage (0.5 hearts) while keeping wind burst working.
+A highly configurable Fabric mod that allows you to control mace damage on your server. Set custom damage values, enable/disable for specific entity types (passive mobs, hostile mobs, bosses, players), and manage custom entity lists - all while keeping the wind burst enchantment fully functional.
+
+## Features
+
+- ⚙️ **Configurable Damage**: Set any damage value for mace attacks
+- 🎯 **Entity Categories**: Separate control for passive mobs, hostile mobs, bosses, and players
+- 📝 **Custom Entity Lists**: Add specific entities to whitelist or blacklist
+- 💾 **Persistent Config**: Settings saved to `config/mace-neutralizer.json`
+- 🎮 **In-Game Commands**: Full control without editing files
+- 🌪️ **Wind Burst Compatible**: Enchantment works normally
+- 🔒 **Server-Side Only**: Clients don't need the mod installed
 
 ## Installation
 
-Put `mace-neutralizer-1.0.0.jar` in your server's `mods` folder. Clients don't need the mod.
-
-## Building
-
-```bash
-./gradlew build
-```
+1. Download the latest `mace-neutralizer-*.jar` from [Releases](https://github.com/sahibkhokhar/mace-neutralizer/releases)
+2. Place it in your server's `mods` folder
+3. Start the server - config file will be auto-generated
 
 ## Requirements
 
 - Minecraft 1.21.11
 - Fabric Loader 0.18.4+
+- Fabric API 0.141.3+
 - Java 21+
 
+## Configuration
+
+Configuration is stored in `config/mace-neutralizer.json` and can be edited directly or via commands.
+
+### Default Configuration
+
+```json
+{
+  "enabled": true,
+  "damageAmount": 1.0,
+  "affectPassiveMobs": true,
+  "affectHostileMobs": true,
+  "affectBosses": true,
+  "affectPlayers": false,
+  "customAffectedEntities": [],
+  "customExcludedEntities": []
+}
+```
+
+### Configuration Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `enabled` | boolean | `true` | Master toggle for the mod |
+| `damageAmount` | float | `1.0` | Damage dealt by mace (2.0 = 1 heart) |
+| `affectPassiveMobs` | boolean | `true` | Apply to passive mobs (cows, pigs, sheep, etc.) |
+| `affectHostileMobs` | boolean | `true` | Apply to hostile mobs (zombies, skeletons, etc.) |
+| `affectBosses` | boolean | `true` | Apply to bosses (Ender Dragon, Wither, Warden, etc.) |
+| `affectPlayers` | boolean | `false` | Apply to players |
+| `customAffectedEntities` | array | `[]` | Force specific entity classes to be affected |
+| `customExcludedEntities` | array | `[]` | Force specific entity classes to be excluded |
+
+## Commands
+
+All commands require OP level 2 (Gamemaster permission).
+
+### Basic Commands
+
+```
+/maceneutralizer
+/maceneutralizer status
+```
+Shows current configuration and status.
+
+```
+/maceneutralizer toggle
+```
+Toggles the mod on/off.
+
+```
+/maceneutralizer set <true|false>
+```
+Explicitly enable or disable the mod.
+
+```
+/maceneutralizer reload
+```
+Reloads configuration from disk.
+
+### Damage Configuration
+
+```
+/maceneutralizer damage <amount>
+```
+Sets the damage amount (in half-hearts). Examples:
+- `/maceneutralizer damage 1.0` - 0.5 hearts
+- `/maceneutralizer damage 2.0` - 1 heart
+- `/maceneutralizer damage 0.0` - No damage (wind burst still works!)
+
+### Entity Category Management
+
+```
+/maceneutralizer entities passive <true|false>
+```
+Enable/disable for passive mobs (cows, pigs, sheep, chickens, villagers, etc.)
+
+```
+/maceneutralizer entities hostile <true|false>
+```
+Enable/disable for hostile mobs (zombies, skeletons, creepers, spiders, etc.)
+
+```
+/maceneutralizer entities bosses <true|false>
+```
+Enable/disable for bosses (Ender Dragon, Wither, Warden, Elder Guardian)
+
+```
+/maceneutralizer entities players <true|false>
+```
+Enable/disable for players
+
+```
+/maceneutralizer entities list
+```
+Shows current entity category settings.
+
+### Custom Entity Management
+
+Use these commands for fine-grained control over specific entity types.
+
+```
+/maceneutralizer custom add <entity_class>
+```
+Force a specific entity class to be affected (overrides category settings).
+
+Example: `/maceneutralizer custom add net.minecraft.entity.passive.VillagerEntity`
+
+```
+/maceneutralizer custom remove <entity_class>
+```
+Remove an entity from the custom affected list.
+
+```
+/maceneutralizer custom exclude <entity_class>
+```
+Force a specific entity class to be excluded (highest priority).
+
+```
+/maceneutralizer custom unexclude <entity_class>
+```
+Remove an entity from the custom excluded list.
+
+```
+/maceneutralizer custom list
+```
+Shows all custom entity lists.
+
+### Common Entity Classes
+
+For use with custom entity commands:
+
+**Passive Mobs:**
+- `net.minecraft.entity.passive.CowEntity`
+- `net.minecraft.entity.passive.SheepEntity`
+- `net.minecraft.entity.passive.PigEntity`
+- `net.minecraft.entity.passive.ChickenEntity`
+- `net.minecraft.entity.passive.VillagerEntity`
+- `net.minecraft.entity.passive.HorseEntity`
+
+**Hostile Mobs:**
+- `net.minecraft.entity.mob.ZombieEntity`
+- `net.minecraft.entity.mob.SkeletonEntity`
+- `net.minecraft.entity.mob.CreeperEntity`
+- `net.minecraft.entity.mob.SpiderEntity`
+- `net.minecraft.entity.mob.EndermanEntity`
+
+**Bosses:**
+- `net.minecraft.entity.boss.dragon.EnderDragonEntity`
+- `net.minecraft.entity.boss.WitherEntity`
+- `net.minecraft.entity.mob.WardenEntity`
+- `net.minecraft.entity.mob.ElderGuardianEntity`
+
+## Usage Examples
+
+### Example 1: PvE Server Setup
+Disable mace for all mobs but keep it normal for players:
+```
+/maceneutralizer entities passive true
+/maceneutralizer entities hostile true
+/maceneutralizer entities bosses true
+/maceneutralizer entities players false
+/maceneutralizer damage 1.0
+```
+
+### Example 2: Boss-Only Challenge
+Only affect boss mobs:
+```
+/maceneutralizer entities passive false
+/maceneutralizer entities hostile false
+/maceneutralizer entities bosses true
+/maceneutralizer entities players false
+```
+
+### Example 3: Protect Villagers Only
+Disable mace damage for villagers specifically:
+```
+/maceneutralizer custom exclude net.minecraft.entity.passive.VillagerEntity
+```
+
+### Example 4: Zero-Damage Wind Burst
+Keep wind burst knockback but deal no damage:
+```
+/maceneutralizer damage 0.0
+```
+
+## Priority System
+
+Entity filtering follows this priority order:
+
+1. **Custom Excluded Entities** (highest priority) - Never affected
+2. **Custom Affected Entities** - Always affected
+3. **Entity Categories** - Based on passive/hostile/boss/player settings
+4. **Default** - Unknown entity types are not affected
+
+## Building from Source
+
+```bash
+git clone https://github.com/sahibkhokhar/mace-neutralizer.git
+cd mace-neutralizer
+./gradlew build
+```
+
+The built jar will be in `build/libs/`.
+
+## Compatibility
+
+- ✅ Works server-side only (clients don't need it)
+- ✅ Compatible with wind burst enchantment
+- ✅ Thread-safe configuration
+- ✅ Multiplayer compatible
+- ✅ Works with modded entities (use custom entity lists)
+
+## Support
+
+- **Issues**: [GitHub Issues](https://github.com/sahibkhokhar/mace-neutralizer/issues)
+- **Source**: [GitHub Repository](https://github.com/sahibkhokhar/mace-neutralizer)
+
+## License
+
+This mod is available under the CC0-1.0 license.
+
+## Changelog
+
+### v1.1.0 (Upcoming)
+- Added comprehensive configuration system
+- Added entity category filtering (passive, hostile, bosses, players)
+- Added custom entity whitelist/blacklist
+- Added configurable damage values
+- Added persistent JSON configuration
+- Rewrote command system with extensive subcommands
+- Added tab completion for entity classes
+- Added detailed status displays
+
+### v1.0.1
+- Updated to Minecraft 1.21.11
+- Fixed permission system for new API
+
+### v1.0.0
+- Initial release for Minecraft 1.21.10
+- Basic mace damage neutralization
+- Simple toggle command

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ loader_version=0.18.4
 loom_version=1.13-SNAPSHOT
 
 # Mod Properties
-mod_version=1.0.1
+mod_version=1.1.0
 maven_group=name.modid
 archives_base_name=mace-neutralizer
 

--- a/src/main/java/name/modid/MaceNeutralizerCommand.java
+++ b/src/main/java/name/modid/MaceNeutralizerCommand.java
@@ -1,36 +1,309 @@
 package name.modid;
 
 import com.mojang.brigadier.arguments.BoolArgumentType;
+import com.mojang.brigadier.arguments.FloatArgumentType;
+import com.mojang.brigadier.arguments.StringArgumentType;
+import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.suggestion.Suggestions;
+import com.mojang.brigadier.suggestion.SuggestionsBuilder;
 import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
+import net.minecraft.command.CommandSource;
 import net.minecraft.command.DefaultPermissions;
 import net.minecraft.server.command.CommandManager;
+import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.text.Text;
 
+import java.util.concurrent.CompletableFuture;
+
 public class MaceNeutralizerCommand {
+	
 	public static void register() {
 		CommandRegistrationCallback.EVENT.register((dispatcher, registryAccess, environment) -> {
 			dispatcher.register(CommandManager.literal("maceneutralizer")
 				.requires(source -> source.getPermissions().hasPermission(DefaultPermissions.GAMEMASTERS)) // Requires OP level 2
+				
+				// /maceneutralizer - shows current status
+				.executes(context -> {
+					return showStatus(context);
+				})
+				
+				// /maceneutralizer toggle - toggles enabled state
 				.then(CommandManager.literal("toggle")
 					.executes(context -> {
 						MaceNeutralizerConfig.toggle();
 						boolean enabled = MaceNeutralizerConfig.isEnabled();
-						context.getSource().sendFeedback(() -> Text.literal("Mace Neutralizer is now " + (enabled ? "enabled" : "disabled")), true);
+						context.getSource().sendFeedback(() -> Text.literal("§aMace Neutralizer is now " + (enabled ? "§2enabled" : "§cdisabled")), true);
 						return enabled ? 1 : 0;
 					}))
+				
+				// /maceneutralizer set <true|false> - sets enabled state
 				.then(CommandManager.literal("set")
 					.then(CommandManager.argument("enabled", BoolArgumentType.bool())
 						.executes(context -> {
 							boolean enabled = BoolArgumentType.getBool(context, "enabled");
 							MaceNeutralizerConfig.setEnabled(enabled);
-							context.getSource().sendFeedback(() -> Text.literal("Mace Neutralizer is now " + (enabled ? "enabled" : "disabled")), true);
+							context.getSource().sendFeedback(() -> Text.literal("§aMace Neutralizer is now " + (enabled ? "§2enabled" : "§cdisabled")), true);
 							return enabled ? 1 : 0;
 						})))
-				.executes(context -> {
-					boolean enabled = MaceNeutralizerConfig.isEnabled();
-					context.getSource().sendFeedback(() -> Text.literal("Mace Neutralizer is currently " + (enabled ? "enabled" : "disabled")), false);
-					return enabled ? 1 : 0;
-				}));
+				
+				// /maceneutralizer status - shows detailed status
+				.then(CommandManager.literal("status")
+					.executes(context -> {
+						return showStatus(context);
+					}))
+				
+				// /maceneutralizer damage <amount> - sets damage amount
+				.then(CommandManager.literal("damage")
+					.then(CommandManager.argument("amount", FloatArgumentType.floatArg(0.0f))
+						.executes(context -> {
+							float amount = FloatArgumentType.getFloat(context, "amount");
+							MaceNeutralizerConfig.setDamageAmount(amount);
+							float hearts = amount / 2.0f;
+							context.getSource().sendFeedback(() -> Text.literal(
+								String.format("§aMace damage set to §e%.1f §a(§e%.1f hearts§a)", amount, hearts)
+							), true);
+							return 1;
+						})))
+				
+				// /maceneutralizer entities - entity category management
+				.then(CommandManager.literal("entities")
+					// /maceneutralizer entities passive <true|false>
+					.then(CommandManager.literal("passive")
+						.then(CommandManager.argument("enabled", BoolArgumentType.bool())
+							.executes(context -> {
+								boolean enabled = BoolArgumentType.getBool(context, "enabled");
+								MaceNeutralizerConfig.setAffectPassiveMobs(enabled);
+								context.getSource().sendFeedback(() -> Text.literal(
+									"§aPassive mobs are now " + (enabled ? "§2affected" : "§cnot affected")
+								), true);
+								return 1;
+							})))
+					
+					// /maceneutralizer entities hostile <true|false>
+					.then(CommandManager.literal("hostile")
+						.then(CommandManager.argument("enabled", BoolArgumentType.bool())
+							.executes(context -> {
+								boolean enabled = BoolArgumentType.getBool(context, "enabled");
+								MaceNeutralizerConfig.setAffectHostileMobs(enabled);
+								context.getSource().sendFeedback(() -> Text.literal(
+									"§aHostile mobs are now " + (enabled ? "§2affected" : "§cnot affected")
+								), true);
+								return 1;
+							})))
+					
+					// /maceneutralizer entities bosses <true|false>
+					.then(CommandManager.literal("bosses")
+						.then(CommandManager.argument("enabled", BoolArgumentType.bool())
+							.executes(context -> {
+								boolean enabled = BoolArgumentType.getBool(context, "enabled");
+								MaceNeutralizerConfig.setAffectBosses(enabled);
+								context.getSource().sendFeedback(() -> Text.literal(
+									"§aBosses are now " + (enabled ? "§2affected" : "§cnot affected")
+								), true);
+								return 1;
+							})))
+					
+					// /maceneutralizer entities players <true|false>
+					.then(CommandManager.literal("players")
+						.then(CommandManager.argument("enabled", BoolArgumentType.bool())
+							.executes(context -> {
+								boolean enabled = BoolArgumentType.getBool(context, "enabled");
+								MaceNeutralizerConfig.setAffectPlayers(enabled);
+								context.getSource().sendFeedback(() -> Text.literal(
+									"§aPlayers are now " + (enabled ? "§2affected" : "§cnot affected")
+								), true);
+								return 1;
+							})))
+					
+					// /maceneutralizer entities list - shows current settings
+					.then(CommandManager.literal("list")
+						.executes(context -> {
+							return showEntitySettings(context);
+						})))
+				
+				// /maceneutralizer custom - custom entity management
+				.then(CommandManager.literal("custom")
+					// /maceneutralizer custom add <entity_class>
+					.then(CommandManager.literal("add")
+						.then(CommandManager.argument("entity_class", StringArgumentType.string())
+							.suggests((context, builder) -> suggestEntityClasses(context, builder))
+							.executes(context -> {
+								String entityClass = StringArgumentType.getString(context, "entity_class");
+								MaceNeutralizerConfig.addCustomAffectedEntity(entityClass);
+								context.getSource().sendFeedback(() -> Text.literal(
+									"§aAdded §e" + entityClass + "§a to custom affected entities"
+								), true);
+								return 1;
+							})))
+					
+					// /maceneutralizer custom remove <entity_class>
+					.then(CommandManager.literal("remove")
+						.then(CommandManager.argument("entity_class", StringArgumentType.string())
+							.suggests((context, builder) -> suggestCustomAffectedEntities(context, builder))
+							.executes(context -> {
+								String entityClass = StringArgumentType.getString(context, "entity_class");
+								MaceNeutralizerConfig.removeCustomAffectedEntity(entityClass);
+								context.getSource().sendFeedback(() -> Text.literal(
+									"§aRemoved §e" + entityClass + "§a from custom affected entities"
+								), true);
+								return 1;
+							})))
+					
+					// /maceneutralizer custom exclude <entity_class>
+					.then(CommandManager.literal("exclude")
+						.then(CommandManager.argument("entity_class", StringArgumentType.string())
+							.suggests((context, builder) -> suggestEntityClasses(context, builder))
+							.executes(context -> {
+								String entityClass = StringArgumentType.getString(context, "entity_class");
+								MaceNeutralizerConfig.addCustomExcludedEntity(entityClass);
+								context.getSource().sendFeedback(() -> Text.literal(
+									"§aAdded §e" + entityClass + "§a to custom excluded entities"
+								), true);
+								return 1;
+							})))
+					
+					// /maceneutralizer custom unexclude <entity_class>
+					.then(CommandManager.literal("unexclude")
+						.then(CommandManager.argument("entity_class", StringArgumentType.string())
+							.suggests((context, builder) -> suggestCustomExcludedEntities(context, builder))
+							.executes(context -> {
+								String entityClass = StringArgumentType.getString(context, "entity_class");
+								MaceNeutralizerConfig.removeCustomExcludedEntity(entityClass);
+								context.getSource().sendFeedback(() -> Text.literal(
+									"§aRemoved §e" + entityClass + "§a from custom excluded entities"
+								), true);
+								return 1;
+							})))
+					
+					// /maceneutralizer custom list - shows custom entities
+					.then(CommandManager.literal("list")
+						.executes(context -> {
+							return showCustomEntities(context);
+						})))
+				
+				// /maceneutralizer reload - reloads config from disk
+				.then(CommandManager.literal("reload")
+					.executes(context -> {
+						MaceNeutralizerConfig.load();
+						context.getSource().sendFeedback(() -> Text.literal("§aReloaded Mace Neutralizer configuration from disk"), true);
+						return 1;
+					}))
+			);
 		});
+	}
+	
+	private static int showStatus(CommandContext<ServerCommandSource> context) {
+		MaceNeutralizerConfig.ConfigData config = MaceNeutralizerConfig.getConfigData();
+		float hearts = config.damageAmount / 2.0f;
+		
+		context.getSource().sendFeedback(() -> Text.literal("§6§l=== Mace Neutralizer Status ==="), false);
+		context.getSource().sendFeedback(() -> Text.literal(
+			"§eEnabled: " + (config.enabled ? "§2✓ Yes" : "§c✗ No")
+		), false);
+		context.getSource().sendFeedback(() -> Text.literal(
+			String.format("§eDamage Amount: §f%.1f §7(%.1f hearts)", config.damageAmount, hearts)
+		), false);
+		context.getSource().sendFeedback(() -> Text.literal(""), false);
+		context.getSource().sendFeedback(() -> Text.literal("§6Entity Categories:"), false);
+		context.getSource().sendFeedback(() -> Text.literal(
+			"  §ePassive Mobs: " + (config.affectPassiveMobs ? "§2✓" : "§c✗")
+		), false);
+		context.getSource().sendFeedback(() -> Text.literal(
+			"  §eHostile Mobs: " + (config.affectHostileMobs ? "§2✓" : "§c✗")
+		), false);
+		context.getSource().sendFeedback(() -> Text.literal(
+			"  §eBosses: " + (config.affectBosses ? "§2✓" : "§c✗")
+		), false);
+		context.getSource().sendFeedback(() -> Text.literal(
+			"  §ePlayers: " + (config.affectPlayers ? "§2✓" : "§c✗")
+		), false);
+		
+		if (!config.customAffectedEntities.isEmpty() || !config.customExcludedEntities.isEmpty()) {
+			context.getSource().sendFeedback(() -> Text.literal(""), false);
+			context.getSource().sendFeedback(() -> Text.literal(
+				"§6Custom Entities: §7(use /maceneutralizer custom list)"
+			), false);
+		}
+		
+		return 1;
+	}
+	
+	private static int showEntitySettings(CommandContext<ServerCommandSource> context) {
+		MaceNeutralizerConfig.ConfigData config = MaceNeutralizerConfig.getConfigData();
+		
+		context.getSource().sendFeedback(() -> Text.literal("§6§l=== Entity Category Settings ==="), false);
+		context.getSource().sendFeedback(() -> Text.literal(
+			"§ePassive Mobs: " + (config.affectPassiveMobs ? "§2✓ Affected" : "§c✗ Not Affected")
+		), false);
+		context.getSource().sendFeedback(() -> Text.literal(
+			"§eHostile Mobs: " + (config.affectHostileMobs ? "§2✓ Affected" : "§c✗ Not Affected")
+		), false);
+		context.getSource().sendFeedback(() -> Text.literal(
+			"§eBosses: " + (config.affectBosses ? "§2✓ Affected" : "§c✗ Not Affected")
+		), false);
+		context.getSource().sendFeedback(() -> Text.literal(
+			"§ePlayers: " + (config.affectPlayers ? "§2✓ Affected" : "§c✗ Not Affected")
+		), false);
+		
+		return 1;
+	}
+	
+	private static int showCustomEntities(CommandContext<ServerCommandSource> context) {
+		MaceNeutralizerConfig.ConfigData config = MaceNeutralizerConfig.getConfigData();
+		
+		context.getSource().sendFeedback(() -> Text.literal("§6§l=== Custom Entity Lists ==="), false);
+		
+		context.getSource().sendFeedback(() -> Text.literal("§eCustom Affected Entities:"), false);
+		if (config.customAffectedEntities.isEmpty()) {
+			context.getSource().sendFeedback(() -> Text.literal("  §7(none)"), false);
+		} else {
+			for (String entity : config.customAffectedEntities) {
+				context.getSource().sendFeedback(() -> Text.literal("  §a+ §f" + entity), false);
+			}
+		}
+		
+		context.getSource().sendFeedback(() -> Text.literal(""), false);
+		context.getSource().sendFeedback(() -> Text.literal("§eCustom Excluded Entities:"), false);
+		if (config.customExcludedEntities.isEmpty()) {
+			context.getSource().sendFeedback(() -> Text.literal("  §7(none)"), false);
+		} else {
+			for (String entity : config.customExcludedEntities) {
+				context.getSource().sendFeedback(() -> Text.literal("  §c- §f" + entity), false);
+			}
+		}
+		
+		context.getSource().sendFeedback(() -> Text.literal(""), false);
+		context.getSource().sendFeedback(() -> Text.literal("§7Note: Custom lists override category settings"), false);
+		
+		return 1;
+	}
+	
+	private static CompletableFuture<Suggestions> suggestEntityClasses(CommandContext<ServerCommandSource> context, SuggestionsBuilder builder) {
+		// Suggest common entity class names
+		String[] suggestions = {
+			"net.minecraft.entity.passive.CowEntity",
+			"net.minecraft.entity.passive.SheepEntity",
+			"net.minecraft.entity.passive.PigEntity",
+			"net.minecraft.entity.passive.ChickenEntity",
+			"net.minecraft.entity.passive.VillagerEntity",
+			"net.minecraft.entity.mob.ZombieEntity",
+			"net.minecraft.entity.mob.SkeletonEntity",
+			"net.minecraft.entity.mob.CreeperEntity",
+			"net.minecraft.entity.mob.SpiderEntity",
+			"net.minecraft.entity.mob.EndermanEntity",
+			"net.minecraft.entity.boss.WitherEntity",
+			"net.minecraft.entity.boss.dragon.EnderDragonEntity",
+			"net.minecraft.entity.mob.WardenEntity"
+		};
+		
+		return CommandSource.suggestMatching(suggestions, builder);
+	}
+	
+	private static CompletableFuture<Suggestions> suggestCustomAffectedEntities(CommandContext<ServerCommandSource> context, SuggestionsBuilder builder) {
+		return CommandSource.suggestMatching(MaceNeutralizerConfig.getCustomAffectedEntities(), builder);
+	}
+	
+	private static CompletableFuture<Suggestions> suggestCustomExcludedEntities(CommandContext<ServerCommandSource> context, SuggestionsBuilder builder) {
+		return CommandSource.suggestMatching(MaceNeutralizerConfig.getCustomExcludedEntities(), builder);
 	}
 }

--- a/src/main/java/name/modid/MaceNeutralizerConfig.java
+++ b/src/main/java/name/modid/MaceNeutralizerConfig.java
@@ -356,8 +356,7 @@ public class MaceNeutralizerConfig {
 		return entity instanceof EnderDragonEntity ||
 		       entity instanceof WitherEntity ||
 		       entity instanceof WardenEntity ||
-		       entity instanceof ElderGuardianEntity ||
-		       entity.isInvulnerableTo(entity.getWorld().getDamageSources().dragonBreath());
+		       entity instanceof ElderGuardianEntity;
 	}
 	
 	/**

--- a/src/main/java/name/modid/MaceNeutralizerConfig.java
+++ b/src/main/java/name/modid/MaceNeutralizerConfig.java
@@ -1,19 +1,383 @@
 package name.modid;
 
-import java.util.concurrent.atomic.AtomicBoolean;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import net.minecraft.entity.boss.BossBar;
+import net.minecraft.entity.boss.WitherEntity;
+import net.minecraft.entity.boss.dragon.EnderDragonEntity;
+import net.minecraft.entity.mob.HostileEntity;
+import net.minecraft.entity.mob.Monster;
+import net.minecraft.entity.passive.PassiveEntity;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.mob.WardenEntity;
+import net.minecraft.entity.boss.WitherEntity;
+import net.minecraft.entity.mob.ElderGuardianEntity;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 public class MaceNeutralizerConfig {
-	private static final AtomicBoolean enabled = new AtomicBoolean(true);
+	private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
+	private static final Path CONFIG_PATH = Path.of("config", "mace-neutralizer.json");
+	private static final ReadWriteLock lock = new ReentrantReadWriteLock();
+	
+	private static ConfigData data = new ConfigData();
+	
+	public static class ConfigData {
+		// General settings
+		public boolean enabled = true;
+		public float damageAmount = 1.0f;
+		
+		// Entity category settings
+		public boolean affectPassiveMobs = true;
+		public boolean affectHostileMobs = true;
+		public boolean affectBosses = true;
+		public boolean affectPlayers = false;
+		
+		// Custom entity types (by class name)
+		public Set<String> customAffectedEntities = new HashSet<>();
+		public Set<String> customExcludedEntities = new HashSet<>();
+		
+		public ConfigData() {}
+	}
+	
+	/**
+	 * Loads the config from disk. Creates default config if it doesn't exist.
+	 */
+	public static void load() {
+		lock.writeLock().lock();
+		try {
+			File configFile = CONFIG_PATH.toFile();
+			
+			// Create config directory if it doesn't exist
+			if (!configFile.getParentFile().exists()) {
+				configFile.getParentFile().mkdirs();
+			}
+			
+			// Load existing config or create default
+			if (configFile.exists()) {
+				try (FileReader reader = new FileReader(configFile)) {
+					ConfigData loadedData = GSON.fromJson(reader, ConfigData.class);
+					if (loadedData != null) {
+						data = loadedData;
+						Maceneutralizer.LOGGER.info("Loaded Mace Neutralizer config from " + CONFIG_PATH);
+					}
+				} catch (Exception e) {
+					Maceneutralizer.LOGGER.error("Failed to load config, using defaults", e);
+					data = new ConfigData();
+				}
+			} else {
+				// Create default config
+				data = new ConfigData();
+				save();
+				Maceneutralizer.LOGGER.info("Created default Mace Neutralizer config at " + CONFIG_PATH);
+			}
+		} finally {
+			lock.writeLock().unlock();
+		}
+	}
+	
+	/**
+	 * Saves the current config to disk.
+	 */
+	public static void save() {
+		lock.readLock().lock();
+		try {
+			File configFile = CONFIG_PATH.toFile();
+			
+			// Ensure parent directory exists
+			if (!configFile.getParentFile().exists()) {
+				configFile.getParentFile().mkdirs();
+			}
+			
+			try (FileWriter writer = new FileWriter(configFile)) {
+				GSON.toJson(data, writer);
+				Maceneutralizer.LOGGER.info("Saved Mace Neutralizer config to " + CONFIG_PATH);
+			} catch (IOException e) {
+				Maceneutralizer.LOGGER.error("Failed to save config", e);
+			}
+		} finally {
+			lock.readLock().unlock();
+		}
+	}
+	
+	// General Settings
 	
 	public static boolean isEnabled() {
-		return enabled.get();
+		lock.readLock().lock();
+		try {
+			return data.enabled;
+		} finally {
+			lock.readLock().unlock();
+		}
 	}
 	
 	public static void setEnabled(boolean value) {
-		enabled.set(value);
+		lock.writeLock().lock();
+		try {
+			data.enabled = value;
+			save();
+		} finally {
+			lock.writeLock().unlock();
+		}
 	}
 	
 	public static void toggle() {
-		enabled.set(!enabled.get());
+		lock.writeLock().lock();
+		try {
+			data.enabled = !data.enabled;
+			save();
+		} finally {
+			lock.writeLock().unlock();
+		}
+	}
+	
+	public static float getDamageAmount() {
+		lock.readLock().lock();
+		try {
+			return data.damageAmount;
+		} finally {
+			lock.readLock().unlock();
+		}
+	}
+	
+	public static void setDamageAmount(float amount) {
+		lock.writeLock().lock();
+		try {
+			data.damageAmount = Math.max(0.0f, amount); // Ensure non-negative
+			save();
+		} finally {
+			lock.writeLock().unlock();
+		}
+	}
+	
+	// Entity Category Settings
+	
+	public static boolean isAffectPassiveMobs() {
+		lock.readLock().lock();
+		try {
+			return data.affectPassiveMobs;
+		} finally {
+			lock.readLock().unlock();
+		}
+	}
+	
+	public static void setAffectPassiveMobs(boolean value) {
+		lock.writeLock().lock();
+		try {
+			data.affectPassiveMobs = value;
+			save();
+		} finally {
+			lock.writeLock().unlock();
+		}
+	}
+	
+	public static boolean isAffectHostileMobs() {
+		lock.readLock().lock();
+		try {
+			return data.affectHostileMobs;
+		} finally {
+			lock.readLock().unlock();
+		}
+	}
+	
+	public static void setAffectHostileMobs(boolean value) {
+		lock.writeLock().lock();
+		try {
+			data.affectHostileMobs = value;
+			save();
+		} finally {
+			lock.writeLock().unlock();
+		}
+	}
+	
+	public static boolean isAffectBosses() {
+		lock.readLock().lock();
+		try {
+			return data.affectBosses;
+		} finally {
+			lock.readLock().unlock();
+		}
+	}
+	
+	public static void setAffectBosses(boolean value) {
+		lock.writeLock().lock();
+		try {
+			data.affectBosses = value;
+			save();
+		} finally {
+			lock.writeLock().unlock();
+		}
+	}
+	
+	public static boolean isAffectPlayers() {
+		lock.readLock().lock();
+		try {
+			return data.affectPlayers;
+		} finally {
+			lock.readLock().unlock();
+		}
+	}
+	
+	public static void setAffectPlayers(boolean value) {
+		lock.writeLock().lock();
+		try {
+			data.affectPlayers = value;
+			save();
+		} finally {
+			lock.writeLock().unlock();
+		}
+	}
+	
+	// Custom Entity Management
+	
+	public static void addCustomAffectedEntity(String entityClassName) {
+		lock.writeLock().lock();
+		try {
+			data.customAffectedEntities.add(entityClassName);
+			save();
+		} finally {
+			lock.writeLock().unlock();
+		}
+	}
+	
+	public static void removeCustomAffectedEntity(String entityClassName) {
+		lock.writeLock().lock();
+		try {
+			data.customAffectedEntities.remove(entityClassName);
+			save();
+		} finally {
+			lock.writeLock().unlock();
+		}
+	}
+	
+	public static void addCustomExcludedEntity(String entityClassName) {
+		lock.writeLock().lock();
+		try {
+			data.customExcludedEntities.add(entityClassName);
+			save();
+		} finally {
+			lock.writeLock().unlock();
+		}
+	}
+	
+	public static void removeCustomExcludedEntity(String entityClassName) {
+		lock.writeLock().lock();
+		try {
+			data.customExcludedEntities.remove(entityClassName);
+			save();
+		} finally {
+			lock.writeLock().unlock();
+		}
+	}
+	
+	public static Set<String> getCustomAffectedEntities() {
+		lock.readLock().lock();
+		try {
+			return new HashSet<>(data.customAffectedEntities);
+		} finally {
+			lock.readLock().unlock();
+		}
+	}
+	
+	public static Set<String> getCustomExcludedEntities() {
+		lock.readLock().lock();
+		try {
+			return new HashSet<>(data.customExcludedEntities);
+		} finally {
+			lock.readLock().unlock();
+		}
+	}
+	
+	/**
+	 * Determines if a given entity should be affected by the mace neutralizer.
+	 * Checks custom lists first, then category settings.
+	 */
+	public static boolean shouldAffectEntity(LivingEntity entity) {
+		if (entity == null) return false;
+		
+		lock.readLock().lock();
+		try {
+			String entityClassName = entity.getClass().getName();
+			
+			// Check custom excluded list first (highest priority)
+			if (data.customExcludedEntities.contains(entityClassName)) {
+				return false;
+			}
+			
+			// Check custom affected list (second priority)
+			if (data.customAffectedEntities.contains(entityClassName)) {
+				return true;
+			}
+			
+			// Check by category
+			
+			// Players
+			if (entity instanceof PlayerEntity) {
+				return data.affectPlayers;
+			}
+			
+			// Bosses (check before hostile since some bosses extend HostileEntity)
+			if (isBoss(entity)) {
+				return data.affectBosses;
+			}
+			
+			// Passive mobs
+			if (entity instanceof PassiveEntity) {
+				return data.affectPassiveMobs;
+			}
+			
+			// Hostile mobs
+			if (entity instanceof HostileEntity || entity instanceof Monster) {
+				return data.affectHostileMobs;
+			}
+			
+			// Default: don't affect unknown entity types
+			return false;
+		} finally {
+			lock.readLock().unlock();
+		}
+	}
+	
+	/**
+	 * Checks if an entity is a boss.
+	 */
+	private static boolean isBoss(LivingEntity entity) {
+		// Check for common boss types
+		return entity instanceof EnderDragonEntity ||
+		       entity instanceof WitherEntity ||
+		       entity instanceof WardenEntity ||
+		       entity instanceof ElderGuardianEntity ||
+		       entity.isInvulnerableTo(entity.getWorld().getDamageSources().dragonBreath());
+	}
+	
+	/**
+	 * Gets a copy of the current config data (for display purposes).
+	 */
+	public static ConfigData getConfigData() {
+		lock.readLock().lock();
+		try {
+			ConfigData copy = new ConfigData();
+			copy.enabled = data.enabled;
+			copy.damageAmount = data.damageAmount;
+			copy.affectPassiveMobs = data.affectPassiveMobs;
+			copy.affectHostileMobs = data.affectHostileMobs;
+			copy.affectBosses = data.affectBosses;
+			copy.affectPlayers = data.affectPlayers;
+			copy.customAffectedEntities = new HashSet<>(data.customAffectedEntities);
+			copy.customExcludedEntities = new HashSet<>(data.customExcludedEntities);
+			return copy;
+		} finally {
+			lock.readLock().unlock();
+		}
 	}
 }

--- a/src/main/java/name/modid/Maceneutralizer.java
+++ b/src/main/java/name/modid/Maceneutralizer.java
@@ -19,7 +19,10 @@ public class Maceneutralizer implements ModInitializer {
 		// However, some things (like resources) may still be uninitialized.
 		// Proceed with mild caution.
 
-		LOGGER.info("Mace Neutralizer mod loaded - mace damage disabled for animals and mobs!");
+		// Load configuration
+		MaceNeutralizerConfig.load();
+		
+		LOGGER.info("Mace Neutralizer mod loaded - mace damage neutralization configured!");
 		
 		// Register the command
 		MaceNeutralizerCommand.register();

--- a/src/main/java/name/modid/mixin/ExampleMixin.java
+++ b/src/main/java/name/modid/mixin/ExampleMixin.java
@@ -6,6 +6,7 @@ import net.minecraft.entity.damage.DamageSource;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
+import net.minecraft.server.world.ServerWorld;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
@@ -18,7 +19,7 @@ public class ExampleMixin {
 		ordinal = 0,
 		argsOnly = true
 	)
-	private float neutralizeMaceDamage(float originalAmount, DamageSource source) {
+	private float neutralizeMaceDamage(float originalAmount, ServerWorld world, DamageSource source) {
 		// Check if mod is enabled
 		if (!MaceNeutralizerConfig.isEnabled()) {
 			return originalAmount;

--- a/src/main/java/name/modid/mixin/ExampleMixin.java
+++ b/src/main/java/name/modid/mixin/ExampleMixin.java
@@ -31,12 +31,12 @@ public class ExampleMixin {
 			
 			// Check if the attacker is holding a mace
 			if (mainHandStack.isOf(Items.MACE)) {
-				// Only neutralize damage for animals and mobs (not players)
+				// Check if this entity type should be affected based on config
 				LivingEntity target = (LivingEntity) (Object) this;
-				if (!(target instanceof PlayerEntity)) {
-					// Set damage to a minimal fixed amount (0.5 hearts = 1.0 damage)
-					// This allows wind burst to work while keeping damage minimal regardless of fall height
-					return 1.0f;
+				if (MaceNeutralizerConfig.shouldAffectEntity(target)) {
+					// Set damage to configured amount
+					// This allows wind burst to work while keeping damage configurable
+					return MaceNeutralizerConfig.getDamageAmount();
 				}
 			}
 		}


### PR DESCRIPTION
Implement a comprehensive configuration and command system for the Mace Neutralizer mod. This allows users to customize mace damage, filter entity types (passive, hostile, bosses, players), and manage custom entity lists via persistent config and in-game commands.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-8ba9b0bc-732f-46e9-8031-0323afa7cfeb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8ba9b0bc-732f-46e9-8031-0323afa7cfeb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

