### PR TITLE
Release push automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,52 @@
+# Create a GitHub release when changes are pushed to main.
+# Uses the version from gradle.properties (mod_version + minecraft_version)
+# to create a release tag in the format v{MOD_VERSION}-mc{MINECRAFT_VERSION}.
+
+name: release
+on:
+  push:
+    branches: [main]
+
+jobs:
+  release:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Get version
+        id: version
+        run: |
+          MOD_VERSION=$(grep '^mod_version=' gradle.properties | cut -d= -f2)
+          MC_VERSION=$(grep '^minecraft_version=' gradle.properties | cut -d= -f2)
+          TAG="v${MOD_VERSION}-mc${MC_VERSION}"
+          echo "tag=${TAG}" >> $GITHUB_OUTPUT
+          echo "mod_version=${MOD_VERSION}" >> $GITHUB_OUTPUT
+          echo "minecraft_version=${MC_VERSION}" >> $GITHUB_OUTPUT
+
+      - name: Validate Gradle wrapper
+        uses: gradle/actions/wrapper-validation@v4
+
+      - name: Setup JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'microsoft'
+
+      - name: Build
+        run: chmod +x ./gradlew && ./gradlew build
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.version.outputs.tag }}
+          name: ${{ steps.version.outputs.tag }}
+          body: |
+            **Mod version:** ${{ steps.version.outputs.mod_version }}
+            **Minecraft version:** ${{ steps.version.outputs.minecraft_version }}
+          files: build/libs/*.jar
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Add a GitHub Actions workflow to automatically create releases on pushes to `main`.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-c4a95c99-fcc7-4bde-854b-e39b544bbcbf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c4a95c99-fcc7-4bde-854b-e39b544bbcbf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

